### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for holiday in JPHoliday.holidays(year: 2015) {
 
 ## Requirement
 
- - iOS 8.0 or later (by Carthage or Cocoapods) / iOS 7 (by manually)
+ - iOS 8.0 or later (by Carthage or CocoaPods) / iOS 7 (by manually)
  - Xcode 7.0 or later
 
 ## Install
@@ -38,7 +38,7 @@ Then, run the following command:
 $ carthage update
 ```
 
-### Cocoapods
+### CocoaPods
 
 Specify it in your Podfile:
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
